### PR TITLE
Extend to_xls to behave like as_json

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = to_xls gem
 
-This gem transform an Array or Hash into a excel file using the spreadsheet gem.
+This gem transform an Array, Hash or a collection of models that implement `to_xls` into a excel file using the spreadsheet gem.
 
 == Usage
 
@@ -13,6 +13,25 @@ This gem transform an Array or Hash into a excel file using the spreadsheet gem.
   @users.to_xls(:columns => [:name, {:company => [:name, :address]}]) # able to pick associations/called methods
   @users.to_xls(:columns => [:name, {:company => [:name, :address]}], :headers => [:name, :company, :address]) # provide better names for the associated columns
 
+
+== Implementing to_xls
+
+You can define a `to_xls(options = {})` method on a model and invoke `to_xls` on a collection of models. This must return a hash, therefore it can be simply implemented as a call to `as_json`. 
+
+  class User
+    def to_xls(options = {})
+      as_json
+    end
+  end
+
+  class Company
+    def to_xls(options = {})
+      {
+        :id => id.to_s,
+        "Name" => name
+      }
+    end
+  end
 
 == Example of use in Rails
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -14,25 +14,6 @@ This gem transform an Array, Hash or a collection of models that implement `to_x
   @users.to_xls(:columns => [:name, {:company => [:name, :address]}], :headers => [:name, :company, :address]) # provide better names for the associated columns
 
 
-== Implementing to_xls
-
-You can define a `to_xls(options = {})` method on a model and invoke `to_xls` on a collection of models. This must return a hash, therefore it can be simply implemented as a call to `as_json`. 
-
-  class User
-    def to_xls(options = {})
-      as_json
-    end
-  end
-
-  class Company
-    def to_xls(options = {})
-      {
-        :id => id.to_s,
-        "Name" => name
-      }
-    end
-  end
-
 == Example of use in Rails
 
 In the controller where you want to export to excel, add the format.xls line.
@@ -47,6 +28,27 @@ In the controller where you want to export to excel, add the format.xls line.
         format.xml { render :xml => @users }
         format.xls { send_data @users.to_xls, :filename => 'users.xls' }
       end
+    end
+  end
+
+== Implementing as_xls
+
+Alternatively, you can define a as_xls(options = {}) method on a model. This should return a hash.
+
+  class Company
+    def as_xls(options = {})
+      {
+        :id => id.to_s,
+        "Name" => name
+      }
+    end
+  end
+
+This way you can also translate the top-level JSON into XLS.
+
+  class User
+    def as_xls(options = {})
+      as_json
     end
   end
 

--- a/lib/to_xls/array_writer.rb
+++ b/lib/to_xls/array_writer.rb
@@ -40,7 +40,7 @@ module ToXls
 
         @array.each do |model|
           row = sheet.row(row_index)
-          fill_row(row, columns, model.respond_to?(:to_xls) ? model.to_xls(@options): model)
+          fill_row(row, columns, model.respond_to?(:as_xls) ? model.as_xls(@options): model)
           row_index += 1
         end
       end
@@ -55,7 +55,7 @@ module ToXls
 
     def can_get_columns_from_first_element?
       @array.first &&
-      @array.first.respond_to?(:to_xls) || (
+      @array.first.respond_to?(:as_xls) || (
         @array.first.respond_to?(:attributes) &&
         @array.first.attributes.respond_to?(:keys) &&
         @array.first.attributes.keys.is_a?(Array)
@@ -63,8 +63,8 @@ module ToXls
     end
 
     def get_columns_from_first_element
-      @array.first.respond_to?(:to_xls) ? 
-        @array.first.to_xls(@options).keys : 
+      @array.first.respond_to?(:as_xls) ? 
+        @array.first.as_xls(@options).keys : 
         @array.first.attributes.keys.sort_by {|sym| sym.to_s}.collect.to_a
     end
 

--- a/spec/array_writer_spec.rb
+++ b/spec/array_writer_spec.rb
@@ -158,16 +158,16 @@ describe ToXls::ArrayWriter do
     end
   end
 
-  describe "#to_xls" do
+  describe "#as_xls" do
     before do
       @mock_users = mock_users
       idx = 0
       @mock_users.each do |user|
-        user.stub!(:to_xls).and_return({ "Name" => user.name, :index => idx  })
+        user.stub!(:as_xls).and_return({ "Name" => user.name, :index => idx  })
         idx += 1
       end
     end
-    it "uses model's to_xls when present" do
+    it "uses model's as_xls when present" do
       xls = make_book(@mock_users)
       check_sheet( xls.worksheets.first,
         [ ["Name", :index],

--- a/spec/array_writer_spec.rb
+++ b/spec/array_writer_spec.rb
@@ -158,7 +158,25 @@ describe ToXls::ArrayWriter do
     end
   end
 
-  
-
+  describe "#to_xls" do
+    before do
+      @mock_users = mock_users
+      idx = 0
+      @mock_users.each do |user|
+        user.stub!(:to_xls).and_return({ "Name" => user.name, :index => idx  })
+        idx += 1
+      end
+    end
+    it "uses model's to_xls when present" do
+      xls = make_book(@mock_users)
+      check_sheet( xls.worksheets.first,
+        [ ["Name", :index],
+          ['Peter', 0],
+          ['John', 1],
+          ['Day9', 2]
+        ]
+      )      
+    end
+  end
 
 end


### PR DESCRIPTION
This enables you to make to_xls behave like with to_json/as_json. So you can now define what XLS conversion returns within the data model. You return a hash.

```
   class User
     def as_xls(options = {})
     {
        "Id" => id.to_s,
        "Name" => name,
     }
     end
  end
```

You can now even define this in terms of json.

```
    class User
      def as_xls(options = {})
        as_json(options)
      end
    end
```

My pull doesn't support deep hashes, I'll do that next if this looks good enough.
