### PR TITLE
Deprecated warning for .all

### DIFF
--- a/lib/to_xls/enumerable_patch.rb
+++ b/lib/to_xls/enumerable_patch.rb
@@ -11,7 +11,7 @@ end
 if defined?(ActiveRecord::Relation)
   class ActiveRecord::Relation
     def to_xls(options = {})
-      self.all.to_xls(options)
+      self.to_a.to_xls(options)
     end
   end
 end


### PR DESCRIPTION
DEPRECATION WARNING: Relation#all is deprecated. If you want to eager-load a relation, you can call #load (e.g. `Post.where(published: true).load`). If you want to get an array of records from a relation, you can call #to_a (e.g. `Post.where(published: true).to_a`). 

By changing the self.to_a we solve the deprecation warning in rails 4.
