### PR TITLE
Remove deprecation warning when using 'all' on active-relation object

### DIFF
--- a/lib/to_xls/enumerable_patch.rb
+++ b/lib/to_xls/enumerable_patch.rb
@@ -11,7 +11,7 @@ end
 if defined?(ActiveRecord::Relation)
   class ActiveRecord::Relation
     def to_xls(options = {})
-      self.all.to_xls(options)
+      self.to_a.to_xls(options)
     end
   end
 end


### PR DESCRIPTION
`all` is depreated on activerelation objects. If arrays are required for `to_xls` to function properly, use `to_a` on activerelation objects instead.
